### PR TITLE
Hang when trajectory array has under 10 points

### DIFF
--- a/turtlebot3_manipulation_bringup/src/turtlebot3_manipulation_bringup.cpp
+++ b/turtlebot3_manipulation_bringup/src/turtlebot3_manipulation_bringup.cpp
@@ -63,7 +63,7 @@ void Turtlebot3ManipulationBringup::armActionCallback(const control_msgs::Follow
       jnt_tra_pts.data.push_back(jnt_tra.points[i].positions[j]);
     }
   }
-  if(jnt_tra_pts_size % POINTS_STEP_SIZE){
+  if(jnt_tra_pts_size % steps){
     //set last positions
     jnt_tra_pts.data.push_back(jnt_tra.points[jnt_tra_pts_size-1].time_from_start.toSec());
     for (std::vector<uint32_t>::size_type j = 0; j < jnt_tra.points[jnt_tra_pts_size-1].positions.size(); j++)

--- a/turtlebot3_manipulation_bringup/src/turtlebot3_manipulation_bringup.cpp
+++ b/turtlebot3_manipulation_bringup/src/turtlebot3_manipulation_bringup.cpp
@@ -48,7 +48,12 @@ void Turtlebot3ManipulationBringup::armActionCallback(const control_msgs::Follow
 
   uint32_t jnt_tra_pts_size = jnt_tra.points.size();
   const uint8_t POINTS_STEP_SIZE = 10;
-  uint32_t steps = floor((double)jnt_tra_pts_size/(double)POINTS_STEP_SIZE);
+  if(jnt_tra_pts_size == 0){
+    //received empty trajectory
+    arm_action_server_.setAborted();
+    return;
+  }
+  uint32_t steps = jnt_tra_pts_size/POINTS_STEP_SIZE + 1;
 
   for (uint32_t i = 0; i < jnt_tra_pts_size; i = i + steps)
   {
@@ -56,6 +61,14 @@ void Turtlebot3ManipulationBringup::armActionCallback(const control_msgs::Follow
     for (std::vector<uint32_t>::size_type j = 0; j < jnt_tra.points[i].positions.size(); j++)
     {
       jnt_tra_pts.data.push_back(jnt_tra.points[i].positions[j]);
+    }
+  }
+  if(jnt_tra_pts_size % POINTS_STEP_SIZE){
+    //set last positions
+    jnt_tra_pts.data.push_back(jnt_tra.points[jnt_tra_pts_size-1].time_from_start.toSec());
+    for (std::vector<uint32_t>::size_type j = 0; j < jnt_tra.points[jnt_tra_pts_size-1].positions.size(); j++)
+    {
+      jnt_tra_pts.data.push_back(jnt_tra.points[jnt_tra_pts_size-1].positions[j]);
     }
   }
   joint_trajectory_point_pub_.publish(jnt_tra_pts);

--- a/turtlebot3_manipulation_bringup/src/turtlebot3_manipulation_bringup.cpp
+++ b/turtlebot3_manipulation_bringup/src/turtlebot3_manipulation_bringup.cpp
@@ -63,7 +63,7 @@ void Turtlebot3ManipulationBringup::armActionCallback(const control_msgs::Follow
       jnt_tra_pts.data.push_back(jnt_tra.points[i].positions[j]);
     }
   }
-  if(jnt_tra_pts_size % steps){
+  if((jnt_tra_pts_size-1) % steps){
     //set last positions
     jnt_tra_pts.data.push_back(jnt_tra.points[jnt_tra_pts_size-1].time_from_start.toSec());
     for (std::vector<uint32_t>::size_type j = 0; j < jnt_tra.points[jnt_tra_pts_size-1].positions.size(); j++)


### PR DESCRIPTION
Line51 has made "steps" zero when jnt_tra_pts_size is less than 10. This cause crash because of infinite push_back.
these commits fix this problem and publish the last points of any size trajectory_points.