### PR TITLE
Add lidar package as exec_depend in bringup package

### DIFF
--- a/turtlebot3_manipulation_bringup/package.xml
+++ b/turtlebot3_manipulation_bringup/package.xml
@@ -12,6 +12,7 @@
   <author email="hjkim@robotis.com">Hye-jong KIM</author>
   <buildtool_depend>ament_cmake</buildtool_depend>
   <exec_depend>gazebo_ros</exec_depend>
+  <exec_depend>hls_lfcd_lds_driver</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>ros2_control</exec_depend>
   <exec_depend>ros2_controllers</exec_depend>


### PR DESCRIPTION
Add `exec_depend` for lidar package so that it can be installed via `rosdep`.